### PR TITLE
fix quote regexp

### DIFF
--- a/parsel.js
+++ b/parsel.js
@@ -120,11 +120,13 @@ export function tokenize (selector) {
 
 	// Replace strings with whitespace strings (to preserve offsets)
 	let strings = [];
-	// FIXME Does not account for escaped backslashes before a quote
-	selector = selector.replace(/(['"])(\\\1|.)+?\1/g, (str, quote, content, start) => {
-		strings.push({str, start});
-		return quote + "§".repeat(content.length) + quote;
-	});
+	selector = selector
+		.replace(/(?:"((?:[^"\\]|\\.)*)")|(?:'((?:[^'\\]|\\.)*)')/g, (str, contentDouble, contentSingle, start) => {
+			strings.push({str, start});
+			const content = (contentDouble === void 0) ? contentSingle : contentDouble;
+			const quote = (contentDouble === void 0) ? '\'' : '"';
+			return quote + "§".repeat(content.length) + quote;
+		});
 
 	// Now that strings are out of the way, extract parens and replace them with parens with whitespace (to preserve offsets)
 	let parens = [], offset = 0, start;


### PR DESCRIPTION
Hi, first thanks for your excellent library !

I found a strange behaviour when using attribute selectors:

```css
a[attr="abcde"][attr="123"]
```

[link](https://projects.verou.me/parsel/?selector=a%5Battr%3D%22abcde%22%5D%5Battr%3D%22123%22%5D)

The second attribute returns:

```json
	{
		"type": "attribute",
		"content": "[attr=\"§\"]",
		"name": "attr",
		"operator": "=",
		"value": "\"§\"",
		"pos": [
			11,
			21
		]
	}
```

Note the `§`. 

I found and fixed the issue on the quote replace regexp.
