### PR TITLE
fix: fix for trimmed attribute selector value

### DIFF
--- a/parsel.js
+++ b/parsel.js
@@ -1,5 +1,5 @@
 export const TOKENS = {
-	attribute: /\[\s*(?:(?<namespace>\*|[-\w]*)\|)?(?<name>[-\w\u{0080}-\u{FFFF}]+)\s*(?:(?<operator>\W?=)\s*(?<value>.+?)\s*(?<caseSensitive>[iIsS])?\s*)?\]/gu,
+	attribute: /\[\s*(?:(?<namespace>\*|[-\w]*)\|)?(?<name>[-\w\u{0080}-\u{FFFF}]+)\s*(?:(?<operator>\W?=)\s*(?<value>.+?)\s*(\s(?<caseSensitive>[iIsS]))?\s*)?\]/gu,
 	id: /#(?<name>(?:[-\w\u{0080}-\u{FFFF}]|\\.)+)/gu,
 	class: /\.(?<name>(?:[-\w\u{0080}-\u{FFFF}]|\\.)+)/gu,
 	comma: /\s*,\s*/g, // must be before combinator


### PR DESCRIPTION
Tiny PR that resolves #17 by adding the required space between the attribute selector value and the case sensitive modifier.
The change in the regexp does not affect the named groups so the match returns the same values but in this case without trimming the values ending with `[sSiI].