### PR TITLE
fix for quoted attributes returning "§" (#26)

### DIFF
--- a/parsel.js
+++ b/parsel.js
@@ -126,8 +126,7 @@ export function tokenize (selector) {
 
 	// Replace strings with whitespace strings (to preserve offsets)
 	let strings = [];
-	// FIXME Does not account for escaped backslashes before a quote
-	selector = selector.replace(/(['"])(\\\1|.)+?\1/g, (str, quote, content, start) => {
+	selector = selector.replace(/(['"])((?:\\\1|.)+?)\1/g, (str, quote, content, start) => {
 		strings.push({str, start});
 		return quote + "§".repeat(content.length) + quote;
 	});


### PR DESCRIPTION
I noticed that when the regex for finding the strings ran, it was not actually finding the entirety of the string (it was grabbing the last character or two). I altered the regex to make the entire string within the quote be selected by making the original `content` variable a non-capturing group and making the repeated group the variable instead.

Doing this seems to fix all the issues where I saw the "§" value appear after tokenization. I manually tested this using any of the examples mentioned in the issue or the other PR attempting a fix:

`footprint[uid="ca135f26-2b55-db63-7451-5a8effb2a19f"] > pad[uid="100a8763-0d5f-de60-23a5-00d74f3ecad7"]`
`[data-abcde="abcde"][data-xyz="xyz"]`
`a[attr="abcde"][attr="123"]`

I also tried more complex examples where quotes may be escaped within the quote:
`div:contains("this isn't \"correct\"")`
`div:contains('this isn\'t correct, "either"')`