### PR TITLE
[package.json] exposes types to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "A tiny, permissive CSS selector parser",
   "main": "dist/cjs/parsel.min.js",
   "module": "dist/parsel.min.js",
+  "types": "./index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/parsel.min.js",
       "require": "./dist/cjs/parsel.min.js",
       "browser": "./parsel.js",


### PR DESCRIPTION
## Description

Fixes https://github.com/LeaVerou/parsel/issues/32

## Changes

As described in https://www.typescriptlang.org/docs/handbook/esm-node.html, we need to expose types in 2 fields:

- top level, for CJS fall-back for older versions of Node.js
- in the `exports` field, as entry-point for TypeScript resolution - must occur first!

```jsonc
// package.json
{
    "name": "my-package",
    "type": "module",
    "exports": {
        ".": {
            // Entry-point for TypeScript resolution - must occur first!
            "types": "./types/index.d.ts",
            // Entry-point for `import "my-package"` in ESM
            "import": "./esm/index.js",
            // Entry-point for `require("my-package") in CJS
            "require": "./commonjs/index.cjs",
        },
    },
    // CJS fall-back for older versions of Node.js
    "main": "./commonjs/index.cjs",
    // Fall-back for older versions of TypeScript
    "types": "./types/index.d.ts"
}
```
