### PR TITLE
Do not export `tokenizeBy`

### DIFF
--- a/parsel.ts
+++ b/parsel.ts
@@ -67,7 +67,7 @@ export function gobbleParens(text: string, offset: number): string {
 	throw new Error(`Mismatched parenthesis starting at offset ${offset}`);
 }
 
-export function tokenizeBy(text: string, grammar = TOKENS): Token[] {
+function tokenizeBy(text: string, grammar = TOKENS): Token[] {
 	if (!text) {
 		return [];
 	}


### PR DESCRIPTION
`tokenizeBy` is not a useful utility without replacements. Usage of `tokenizeBy` should be replaced with `tokenize`.