### PR TITLE
fix: use `cjs` extension for cjs entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "version": "1.1.1",
   "description": "A tiny, permissive CSS selector parser",
   "type": "module",
-  "main": "dist/cjs/parsel.min.js",
+  "main": "dist/cjs/parsel.min.cjs",
   "module": "dist/parsel.min.js",
   "types": "./dist/parsel.d.ts",
   "exports": {
     ".": {
       "browser": "./dist/parsel.js",
       "import": "./dist/parsel.min.js",
-      "require": "./dist/cjs/parsel.min.js",
+      "require": "./dist/cjs/parsel.min.cjs",
       "types": "./dist/parsel.d.ts",
       "umd": "./dist/umd/parsel.min.js"
     }

--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "version": "1.1.1",
   "description": "A tiny, permissive CSS selector parser",
   "type": "module",
-  "main": "dist/cjs/parsel.min.cjs",
+  "main": "dist/parsel.min.cjs",
   "module": "dist/parsel.min.js",
   "types": "./dist/parsel.d.ts",
   "exports": {
     ".": {
       "browser": "./dist/parsel.js",
       "import": "./dist/parsel.min.js",
-      "require": "./dist/cjs/parsel.min.cjs",
+      "require": "./dist/parsel.min.cjs",
       "types": "./dist/parsel.d.ts",
       "umd": "./dist/umd/parsel.min.js"
     }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ export default [
 		input: 'parsel.ts',
 		output: [
 			{
-				file: 'dist/cjs/parsel.cjs',
+				file: 'dist/parsel.cjs',
 				format: 'cjs',
 			},
 			{
@@ -26,7 +26,7 @@ export default [
 		].concat(
 			[
 				{
-					file: 'dist/cjs/parsel.min.cjs',
+					file: 'dist/parsel.min.cjs',
 					format: 'cjs',
 				},
 				{

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ export default [
 		input: 'parsel.ts',
 		output: [
 			{
-				file: 'dist/cjs/parsel.js',
+				file: 'dist/cjs/parsel.cjs',
 				format: 'cjs',
 			},
 			{
@@ -26,7 +26,7 @@ export default [
 		].concat(
 			[
 				{
-					file: 'dist/cjs/parsel.min.js',
+					file: 'dist/cjs/parsel.min.cjs',
 					format: 'cjs',
 				},
 				{


### PR DESCRIPTION
Updates entrypoints and export maps for cjs to `parsel.min.cjs`

Fixes #73