### PR TITLE
Add support for relative selector lists

### DIFF
--- a/parsel.ts
+++ b/parsel.ts
@@ -260,6 +260,14 @@ function nestTokens(tokens: Token[], { list = true } = {}): AST {
 			let left = tokens.slice(0, i);
 			let right = tokens.slice(i + 1);
 
+			if (left.length === 0) {
+				return {
+					type: 'relative',
+					combinator: token.content,
+					right: nestTokens(right),
+				};
+			}
+
 			return {
 				type: 'complex',
 				combinator: token.content,
@@ -301,6 +309,9 @@ export function* flatten(
 			break;
 		case 'complex':
 			yield* flatten(node.left, node);
+			yield* flatten(node.right, node);
+			break;
+		case 'relative':
 			yield* flatten(node.right, node);
 			break;
 		case 'compound':
@@ -561,6 +572,12 @@ export interface Complex {
 	left: AST;
 }
 
+export interface Relative {
+	type: 'relative';
+	combinator: string;
+	right: AST;
+}
+
 export interface Compound {
 	type: 'compound';
 	list: Token[];
@@ -571,4 +588,4 @@ export interface List {
 	list: AST[];
 }
 
-export type AST = Complex | Compound | List | Token;
+export type AST = Complex | Relative | Compound | List | Token;

--- a/test.json
+++ b/test.json
@@ -965,5 +965,85 @@
 				8
 			]
 		}
+	},
+	{
+		"type": "tokenize",
+		"input": ".container:has(~ .image)",
+		"expected": [
+			{
+				"name": "container",
+				"type": "class",
+				"content": ".container",
+				"pos": [
+					0,
+					10
+				]
+			},
+			{
+				"name": "has",
+				"argument": "~ .image",
+				"type": "pseudo-class",
+				"content": ":has(~ .image)",
+				"pos": [
+					10,
+					24
+				]
+			}
+		]
+	},
+	{
+		"type": "parse",
+		"input": ".container:has(~ .image)",
+		"expected": {
+			"type": "compound",
+			"list": [
+				{
+					"name": "container",
+					"type": "class",
+					"content": ".container",
+					"pos": [
+						0,
+						10
+					]
+				},
+				{
+					"name": "has",
+					"argument": "~ .image",
+					"type": "pseudo-class",
+					"content": ":has(~ .image)",
+					"pos": [
+						10,
+						24
+					],
+					"subtree": {
+						"type": "relative",
+						"combinator": "~",
+						"right": {
+							"name": "image",
+							"type": "class",
+							"content": ".image",
+							"pos": [
+								2,
+								8
+							]
+						}
+					}
+				}
+			]
+		}
+	},
+	{
+		"type": "stringify",
+		"input": ".container:has(~ .image)",
+		"expected": ".container:has(~ .image)"
+	},
+	{
+		"type": "specificity",
+		"input": ".container:has(~ .image)",
+		"expected": [
+			0,
+			2,
+			0
+		]
 	}
 ]


### PR DESCRIPTION
Fixes #74

This PR adds support for relative selectors used in `:has` while making the addition of other relative selector pseudo-classes in the future fairly simple.

I added a new type `Relative` for this but I'm not sure whether or not this is the right design. The CSS spec states that, because `:has()` takes a relative selector list, the arguments of `:has()` are actually complex selectors. However, it seems _a little_ odd to me to treat the `left` side of a complex selector as `null` (but that could be an alternate design), especially since the text talks about complex selectors being compound selectors separated by combinators. So the "first" compound selector would be nothing in the relative case — somehow feels wrong from the definition.

Thoughts?