### PR TITLE
Include combinators when stringifying (sub)trees

### DIFF
--- a/parsel.ts
+++ b/parsel.ts
@@ -393,13 +393,24 @@ export function parse(
  * Converts the given list or (sub)tree to a string.
  */
 export function stringify(listOrNode: Token[] | AST): string {
-	let tokens: Token[];
 	if (Array.isArray(listOrNode)) {
-		tokens = listOrNode;
-	} else {
-		tokens = [...flatten(listOrNode)].map(([token]) => token);
+		return listOrNode.map((token) => token.content).join("");
 	}
-	return tokens.map(token => token.content).join('')
+
+	switch (listOrNode.type) {
+		case "list":
+			return listOrNode.list.map(stringify).join(",");
+		case "complex":
+			return (
+				stringify(listOrNode.left) +
+				listOrNode.combinator +
+				stringify(listOrNode.right)
+			);
+		case "compound":
+			return listOrNode.list.map(stringify).join("");
+		default:
+			return listOrNode.content;
+	}
 }
 
 /**

--- a/test.html
+++ b/test.html
@@ -27,8 +27,12 @@ const tests = {
 		name: 'Parsing',
 		tests: []
 	},
-	testStringify: {
-		name: 'Stringifying',
+	testStringifyTokens: {
+		name: 'Stringifying tokens',
+		tests: []
+	},
+	testStringifyAST: {
+		name: 'Stringifying AST',
 		tests: []
 	},
 	testSpecificity: {
@@ -45,7 +49,8 @@ for (const testCase of cases) {
 			tests.testParse.tests.push(testCase);
 			break;
 		case 'stringify':
-			tests.testStringify.tests.push(testCase);
+			tests.testStringifyTokens.tests.push(testCase);
+			tests.testStringifyAST.tests.push(testCase);
 			break;
 		case 'specificity':
 			tests.testSpecificity.tests.push(testCase);
@@ -93,9 +98,17 @@ window.testParse = function(test, result, expected) {
 	return Test.equals(JSON.stringify(JSON.parse(expected.textContent), null, "\t"), actual);
 }
 
-window.testStringify = function(test, result, expected) {
+window.testStringifyTokens = function(test, result, expected) {
 	console.log(arguments)
 	const tokens = parsel.tokenize(test.textContent);
+	const actual = parsel.stringify(tokens);
+	result.textContent = JSON.stringify(actual);
+	return Test.equals(JSON.parse(expected.textContent), actual);
+}
+
+window.testStringifyAST = function(test, result, expected) {
+	console.log(arguments)
+	const tokens = parsel.parse(test.textContent);
 	const actual = parsel.stringify(tokens);
 	result.textContent = JSON.stringify(actual);
 	return Test.equals(JSON.parse(expected.textContent), actual);


### PR DESCRIPTION
The `flatten` function doesn't yield the combinator when given a complex selector, which yields invalid results:

```js
stringify(parse('#lorem > .ipsum')) === '#lorem.ipsum'
stringify(parse('.lorem + div')) === '.loremdiv'
stringify(parse('.lorem div')) === '.loremdiv'
```