### PR TITLE
Fix stringifying relative selectors

### DIFF
--- a/parsel.ts
+++ b/parsel.ts
@@ -411,6 +411,11 @@ export function stringify(listOrNode: Token[] | AST): string {
 	switch (listOrNode.type) {
 		case "list":
 			return listOrNode.list.map(stringify).join(",");
+		case "relative":
+			return (
+				listOrNode.combinator +
+				stringify(listOrNode.right)
+			);
 		case "complex":
 			return (
 				stringify(listOrNode.left) +


### PR DESCRIPTION
I noticed after #75 was merged that the build fails because of the change to stringify in master that I didn't pull into my branch (my bad for not rebasing).

This PR fixes that