### PR TITLE
Fix empty string attribute parsing

### DIFF
--- a/parsel.ts
+++ b/parsel.ts
@@ -131,7 +131,7 @@ export function tokenizeBy(text: string, grammar = TOKENS): Token[] {
 	return tokens as Token[];
 }
 
-const STRING_PATTERN = /(['"])([^\\\n]+?)\1/g;
+const STRING_PATTERN = /(['"])([^\\\n]*?)\1/g;
 const ESCAPE_PATTERN = /\\./g;
 export function tokenize(selector: string, grammar = TOKENS): Token[] {
 	// Prevent leading/trailing whitespaces from being interpreted as combinators

--- a/test.json
+++ b/test.json
@@ -632,6 +632,34 @@
 		]
 	},
 	{
+		"type": "tokenize",
+		"input": "[a=\"\"][b=\"\"]",
+		"expected": [
+			{
+				"name": "a",
+				"operator": "=",
+				"value": "\"\"",
+				"type": "attribute",
+				"content": "[a=\"\"]",
+				"pos": [
+					0,
+					6
+				]
+			},
+			{
+				"name": "b",
+				"operator": "=",
+				"value": "\"\"",
+				"type": "attribute",
+				"content": "[b=\"\"]",
+				"pos": [
+					6,
+					12
+				]
+			}
+		]
+	},
+	{
 		"type": "specificity",
 		"input": "input[type=\"checkbox\"][checked]:indeterminate + label",
 		"expected": [


### PR DESCRIPTION
Here's a fix for a pesky class of selectors that were being parsed incorrectly.

An attribute selector like `[a=""][b=""]` is currently parsed as a single attribute selector instead of two.

<img width="1308" alt="image" src="https://github.com/user-attachments/assets/a7715362-ab8a-48de-b716-eded5848bf8e" />

This seems to be because the string placeholder replacement regex expects all strings to be non-empty.

```diff
-const STRING_PATTERN = /(['"])([^\\\n]+?)\1/g;
+const STRING_PATTERN = /(['"])([^\\\n]*?)\1/g;
```

This is only obvious as a problem when an attribute selector with an empty string value is followed by any quote. Instead of matching just the selector value, the regex runs up until the following quote.

Some additional cases which fail currently.

- `[a=""][b=""]`
- `[a=""]"`
- `[a=""]:not([b=""])`

Might be that trying to entirely exclude empty strings from the placeholder replacement process is a better approach, but not seeing a simple way of doing that without drastically altering the `STRING_PATTERN` regex.